### PR TITLE
Make twilio-client-sample compatible with KITE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Navigate to the folder with the source code on your machine in a terminal window
 
 You will first need to install the application's dependencies. To install them  manually, type the following commands in your terminal:
 
-    pip install twilio==5.7.0 # Since, this implementation has version dependency [ don't support 6.x ]
+    pip install twilio==5.7.0 #Since, this implementation has version dependency [ does not support 6.x ]
     pip install flask
 
 Now, you should be able to launch the application.  From your terminal, run `python run.py`.  This should launch your sinatra application on port 5000 - (127.0.0.1:5000/client?client=tommy)) or (127.0.0.1:5000/reqclient?client=tommy)) .

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Navigate to the folder with the source code on your machine in a terminal window
 
 You will first need to install the application's dependencies. To install them  manually, type the following commands in your terminal:
 
-    pip install twilio
+    pip install twilio==5.7.0 # Since, this implementation has version dependency [ don't support 6.x ]
     pip install flask
 
 Now, you should be able to launch the application.  From your terminal, run `python run.py`.  This should launch your sinatra application on port 5000 - (127.0.0.1:5000/client?client=tommy)) or (127.0.0.1:5000/reqclient?client=tommy)) .

--- a/templates/client.html
+++ b/templates/client.html
@@ -20,17 +20,33 @@
       var conferenceID = "TwilioTest";
       var remoteUserId;
       var params;
+      var KITE = {};
 
       function csInitCallback(err, msg) {
         console.log("CallStats Initializing Status: err=" + err + " msg=" + msg);
+        // KITE binding for csio initialization result.
+        KITE.csInitCallbackResult = {
+          err: err,
+          msg: msg
+        };
       }
 
       function csCallback(err, msg) {
         console.log("CallStats: ", " status: ", err, " msg: ", msg);
+        // KITE binding for csio callstats result.
+        KITE.csCallbackResult = {
+            status: err,
+            msg: msg
+        };
       }
 
       function callback(status, results) {
         console.log("preCallTestResults ", status, results);
+        // KITE binding for precallTextResult callback result
+        KITE.preCallTestResults = {
+            status: status,
+            results: results
+        };
       }
 
       Twilio.Device.setup("{{ token }}");
@@ -48,6 +64,8 @@
       Twilio.Device.error(function (error) {
         $("#log").text("Error: " + error.message);
         console.log("Error ", error);
+        // When a device error occured
+        KITE.deviceError = error;
       });
 
       Twilio.Device.connect(function (conn) {

--- a/templates/client.html
+++ b/templates/client.html
@@ -26,7 +26,7 @@
         console.log("CallStats Initializing Status: err=" + err + " msg=" + msg);
         // KITE binding for csio initialization result.
         KITE.csInitCallbackResult = {
-          err: err,
+          status: err,
           msg: msg
         };
       }


### PR DESCRIPTION
https://app.clubhouse.io/callstatsio/story/8264/modify-twilio-client-sample-source-to-make-it-compatible-with-kite-integration

To access callstats status callback from KITE, we need to bind the method with window, or a scope that is accessible from outside app scope. To do that we introduced a new variable KITE, and assigned csio callback result to KITE.
